### PR TITLE
V2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Fixed** companion radio decoding to be more robust
 - **Added** `channel_index` key to `external_message` dict
 - **Added** Meshtastic ID to messages bridged to MeshCore
+- **Added** contact packet types to protocol handler
 ---
 
 ## Version 2.0.0 - Comprehensive Code Review and Enhancements (December 31, 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **Added** configuration settings for bridging specific channels
 - **Fixed** companion radio decoding to be more robust
 - **Added** `channel_index` key to `external_message` dict
+- **Added** Meshtastic ID to messages bridged to MeshCore
 ---
 
 ## Version 2.0.0 - Comprehensive Code Review and Enhancements (December 31, 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **Added** support for python -m build
 - **Added** configuration settings for bridging specific channels
 - **Fixed** companion radio decoding to be more robust
+- **Added** `channel_index` key to `external_message` dict
 ---
 
 ## Version 2.0.0 - Comprehensive Code Review and Enhancements (December 31, 2025)

--- a/ammb/meshcore_handler.py
+++ b/ammb/meshcore_handler.py
@@ -627,6 +627,10 @@ class MeshcoreHandler:
         # CMD_SEND_CHANNEL_TXT_MSG (3)
         txt_type = 0
         channel_idx = int(item.get("channel_index", 0))
+        sender_meshtastic_id = item.get("sender_meshtastic_id", "Unknown")
+
+        # Prepend Meshtastic ID to outgoing MeshCore message
+        payload = f"{sender_meshtastic_id}: {payload}"
 
         if self.config.meshtastic_channel_index is not None and self.config.meshcore_channel_index is not None:
             if channel_idx == self.config.meshtastic_channel_index:

--- a/ammb/meshtastic_handler.py
+++ b/ammb/meshtastic_handler.py
@@ -264,6 +264,7 @@ class MeshtasticHandler:
                     "timestamp_rx": time.time(),
                     "rx_rssi": packet.get("rxRssi"),
                     "rx_snr": packet.get("rxSnr"),
+                    "channel_index": packet.get("channel"),
                 }
 
                 try:

--- a/ammb/protocol.py
+++ b/ammb/protocol.py
@@ -397,7 +397,54 @@ class MeshcoreCompanionProtocol(MeshcoreProtocolHandler):
                 "protocol": "companion_radio",
             }
 
+        if code == 0x02:  # CONTACT_START
+            return {
+                "companion_kind": "contact_start",
+                "internal_only": True,
+                "protocol": "companion_radio",
+            }
+
+        if code == 0x03:  # CONTACT_INFO
+            return {
+                "companion_kind": "contact_info",
+                "internal_only": True,
+                "protocol": "companion_radio",
+            }
+
+        if code == 0x04:  # CONTACT_END
+            return {
+                "companion_kind": "contact_end",
+                "internal_only": True,
+                "protocol": "companion_radio",
+            }
+
+        if code == 0x05:  # SELF_INFO
+            return {
+                "companion_kind": "self_info",
+                "internal_only": True,
+                "protocol": "companion_radio",
+            }
+
+        if code == 0x0D:  # DEVICE_INFO
+            return {
+                "companion_kind": "device_info",
+                "internal_only": True,
+                "protocol": "companion_radio",
+            }
+
         # --- PUSH codes (unsolicited events from the radio) ---
+
+        if code == 0x80:  # PUSH_CODE_ADVERT
+            if len(raw_data) < 1 + 32:
+                return None
+            pubkey = raw_data[1:33]
+            self.logger.info("MeshCore advert from: %s", pubkey[:4].hex())
+            return {
+                "companion_kind": "advert",
+                "pubkey": pubkey.hex(),
+                "internal_only": True,
+                "protocol": "companion_radio",
+            }
 
         if code == 0x82:  # PUSH_CODE_SEND_CONFIRMED
             if len(raw_data) < 1 + 4 + 4:
@@ -419,14 +466,9 @@ class MeshcoreCompanionProtocol(MeshcoreProtocolHandler):
                 "protocol": "companion_radio",
             }
 
-        if code == 0x80:  # PUSH_CODE_ADVERT
-            if len(raw_data) < 1 + 32:
-                return None
-            pubkey = raw_data[1:33]
-            self.logger.info("MeshCore advert from: %s", pubkey[:4].hex())
+        if code == 0x88:  # PUSH_CODE_LOG_DATA
             return {
-                "companion_kind": "advert",
-                "pubkey": pubkey.hex(),
+                "companion_kind": "log_data",
                 "internal_only": True,
                 "protocol": "companion_radio",
             }
@@ -439,20 +481,6 @@ class MeshcoreCompanionProtocol(MeshcoreProtocolHandler):
             return {
                 "companion_kind": "new_advert",
                 "pubkey": pubkey.hex(),
-                "internal_only": True,
-                "protocol": "companion_radio",
-            }
-
-        if code == 0x0D:  # PUSH_CODE_DEVICE_INFO
-            return {
-                "companion_kind": "device_info",
-                "internal_only": True,
-                "protocol": "companion_radio",
-            }
-
-        if code == 0x88:  # PUSH_CODE_LOG_DATA
-            return {
-                "companion_kind": "log_data",
                 "internal_only": True,
                 "protocol": "companion_radio",
             }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -127,7 +127,8 @@ Messages from Meshtastic are translated to the following format:
   "payload": "Hello from Meshtastic",
   "timestamp_rx": 1704067200.0,
   "rx_rssi": -85,
-  "rx_snr": 5.2
+  "rx_snr": 5.2,
+  "channel_index": 0
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "akita-mesh-bridge"
-version = "2.1.0"
+version = "2.1.1"
 description = "Bridge between Meshtastic and MeshCore networks"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
Hi,

This PR does three things:

1. Adds a `channel_index` key to the `external_message` dict
  The `external_message` dict in the Meshtastic handler is missing the `channel_index` key, which means that `channel_index = decoded_msg.get("channel_index", 0)` in the MeshCore handler will always incorrectly default to 0

2. Adds the Meshtastic ID to messages bridged to MeshCore
   MeshCore messages already prepend the MeshCore ID to messages bridged to Meshtastic, so now conversely, Meshtastic IDs are prepended to messages bridged to MeshCore.
 
3. Adds contact packet types to the protocol handler
   Setting `COMPANION_CONTACTS_POLL_S` > 0 polls for contacts periodically, but the protocol handler cannot process the fetched contact list, resulting in protocol auto-switching being needlessly triggered.
   Rather than ignoring these contact packets and returning `None` from `MeshcoreCompanionProtocol.decode()`, it now returns `internal_only = True`. This sets the groundwork for future full, correct processing of contacts.
